### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/ncruces/julianday v0.1.3
-	github.com/tetratelabs/wazero v1.0.0-pre.7.0.20230117161130-15889085a5ca
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 )
 
 require golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/ncruces/julianday v0.1.3 h1:+JRqsbdGH8QlPWlB6i/pD8sENBZZ1qg24qBCAcYfGMU=
 github.com/ncruces/julianday v0.1.3/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
-github.com/tetratelabs/wazero v1.0.0-pre.7.0.20230117161130-15889085a5ca h1:cvbRnzLE99QnA6HT3yoqXjWEB2JMiyTs3GSLpQZg45A=
-github.com/tetratelabs/wazero v1.0.0-pre.7.0.20230117161130-15889085a5ca/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) 

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
