### PR TITLE
wazero v1.7.0-pre.1.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/ncruces/julianday v1.0.0
 	github.com/psanford/httpreadat v0.1.0
-	github.com/tetratelabs/wazero v1.6.0
+	github.com/tetratelabs/wazero v1.6.1-0.20240307090053-f4b9c018566f
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/ncruces/julianday v1.0.0
 	github.com/psanford/httpreadat v0.1.0
-	github.com/tetratelabs/wazero v1.6.1-0.20240307090053-f4b9c018566f
+	github.com/tetratelabs/wazero v1.7.0-pre.1
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/sys v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt
 github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
 github.com/psanford/httpreadat v0.1.0 h1:VleW1HS2zO7/4c7c7zNl33fO6oYACSagjJIyMIwZLUE=
 github.com/psanford/httpreadat v0.1.0/go.mod h1:Zg7P+TlBm3bYbyHTKv/EdtSJZn3qwbPwpfZ/I9GKCRE=
-github.com/tetratelabs/wazero v1.6.1-0.20240307090053-f4b9c018566f h1:Cft4jA4LGY9iQRyhyZolQQHq4LsDK4Zh4i6p9CKbUTU=
-github.com/tetratelabs/wazero v1.6.1-0.20240307090053-f4b9c018566f/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+github.com/tetratelabs/wazero v1.7.0-pre.1 h1:mOcomS6m5tz4gZgUaocVm0o64uDPPAmErJJmiOVLHvw=
+github.com/tetratelabs/wazero v1.7.0-pre.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt
 github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
 github.com/psanford/httpreadat v0.1.0 h1:VleW1HS2zO7/4c7c7zNl33fO6oYACSagjJIyMIwZLUE=
 github.com/psanford/httpreadat v0.1.0/go.mod h1:Zg7P+TlBm3bYbyHTKv/EdtSJZn3qwbPwpfZ/I9GKCRE=
-github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
-github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
+github.com/tetratelabs/wazero v1.6.1-0.20240307090053-f4b9c018566f h1:Cft4jA4LGY9iQRyhyZolQQHq4LsDK4Zh4i6p9CKbUTU=
+github.com/tetratelabs/wazero v1.6.1-0.20240307090053-f4b9c018566f/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,5 +1,0 @@
-golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
-golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=
-golang.org/x/term v0.17.0/go.mod h1:lLRBjIVuehSbZlaOtGMbcMncT+aqLLLmKrsjNrUguwk=
-golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=

--- a/gormlite/go.mod
+++ b/gormlite/go.mod
@@ -11,6 +11,6 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/ncruces/julianday v1.0.0 // indirect
-	github.com/tetratelabs/wazero v1.6.0 // indirect
-	golang.org/x/sys v0.17.0 // indirect
+	github.com/tetratelabs/wazero v1.7.0-pre.1 // indirect
+	golang.org/x/sys v0.18.0 // indirect
 )

--- a/gormlite/go.sum
+++ b/gormlite/go.sum
@@ -6,10 +6,10 @@ github.com/ncruces/go-sqlite3 v0.12.2 h1:NO8lFyFTA6aUtDWviQX2Rzqi1RX3X52peWq/MLg
 github.com/ncruces/go-sqlite3 v0.12.2/go.mod h1:+8dWcBxb2Yar4EcCwav1a21MpKZbztwOYBLSRYt9bMY=
 github.com/ncruces/julianday v1.0.0 h1:fH0OKwa7NWvniGQtxdJRxAgkBMolni2BjDHaWTxqt7M=
 github.com/ncruces/julianday v1.0.0/go.mod h1:Dusn2KvZrrovOMJuOt0TNXL6tB7U2E8kvza5fFc9G7g=
-github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
-github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
-golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
-golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+github.com/tetratelabs/wazero v1.7.0-pre.1 h1:mOcomS6m5tz4gZgUaocVm0o64uDPPAmErJJmiOVLHvw=
+github.com/tetratelabs/wazero v1.7.0-pre.1/go.mod h1:ytl6Zuh20R/eROuyDaGPkp82O9C/DJfXAwJfQ3X6/7Y=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gorm.io/gorm v1.25.7 h1:VsD6acwRjz2zFxGO50gPO6AkNs7KKnvfzUjHQhZDz/A=


### PR DESCRIPTION
This fails very consistently after updating [wazero](https://wazero.io/) to the [optimizing compiler](https://github.com/tetratelabs/wazero/commit/ccf60cb7a9796fdc52ff771c3bc7e7c72e5a0131).

On:
```
goos: linux
goarch: amd64
cpu: AMD EPYC 7B12
version: go1.22.0 linux/amd64
```

```
=== RUN   TestMemory
panic: wasm error: out of bounds memory access
wasm stack trace:
	.sqlite3FindTable(i32,i32,i32) i32
	.sqlite3LocateTable(i32,i32,i32,i32) i32
	.selectExpander(i32,i32) i32
	.sqlite3WalkSelect(i32,i32) i32
	.sqlite3SelectPrep(i32,i32,i32)
	.sqlite3Select(i32,i32,i32) i32
	.sqlite3RunParser(i32,i32) i32
	.sqlite3Prepare(i32,i32,i32,i32,i32,i32,i32) i32
	.sqlite3LockAndPrepare(i32,i32,i32,i32,i32,i32,i32) i32
	.sqlite3_prepare_v3(i32,i32,i32,i32,i32,i32) i32
	.sqlite3_vtab_config_go(i32,i32,i32) i32

goroutine 8700 [running]:
github.com/ncruces/go-sqlite3.(*sqlite).call(0xc0000b4708, {0x728b5c, 0x12?}, {0xc00047de18?, 0xc00047de08?, 0x68614c?})
	/home/runner/work/go-sqlite3/go-sqlite3/sqlite.go:181 +0x1ad
github.com/ncruces/go-sqlite3.(*Conn).PrepareFlags(0xc0003e4000, {0x72ca56, 0x1a}, 0x3c57b8?)
	/home/runner/work/go-sqlite3/go-sqlite3/conn.go:186 +0x1be
github.com/ncruces/go-sqlite3.(*Conn).Prepare(...)
	/home/runner/work/go-sqlite3/go-sqlite3/conn.go:167
github.com/ncruces/go-sqlite3/tests/parallel.testParallel.func2()
	/home/runner/work/go-sqlite3/go-sqlite3/tests/parallel/parallel_test.go:146 +0xc7
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 5002
	/home/runner/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
FAIL	github.com/ncruces/go-sqlite3/tests/parallel	11.322s
```

On:
```
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
version: go1.22.0 darwin/amd64
```

```
=== RUN   TestMemory
panic: wasm error: out of bounds memory access
wasm stack trace:
        .sqlite3FindTable(i32,i32,i32) i32
        .sqlite3LocateTable(i32,i32,i32,i32) i32
        .selectExpander(i32,i32) i32
        .sqlite3WalkSelect(i32,i32) i32
        .sqlite3SelectPrep(i32,i32,i32)
        .sqlite3Select(i32,i32,i32) i32
        .sqlite3RunParser(i32,i32) i32
        .sqlite3Prepare(i32,i32,i32,i32,i32,i32,i32) i32
        .sqlite3LockAndPrepare(i32,i32,i32,i32,i32,i32,i32) i32
        .sqlite3_prepare_v3(i32,i32,i32,i32,i32,i32) i32
        env.go_cur_rowid(i32,i32) i32

goroutine 6490 [running]:
github.com/ncruces/go-sqlite3.(*sqlite).call(0xc0000de008, {0x942c1a5, 0x12?}, {0xc00076de18?, 0xc00076de08?, 0x941b3ac?})
        /Users/cruces/Documents/Personal/go-sqlite3/sqlite.go:181 +0x1ad
github.com/ncruces/go-sqlite3.(*Conn).PrepareFlags(0xc000862000, {0x942fff1, 0x1a}, 0x0?)
        /Users/cruces/Documents/Personal/go-sqlite3/conn.go:186 +0x1be
github.com/ncruces/go-sqlite3.(*Conn).Prepare(...)
        /Users/cruces/Documents/Personal/go-sqlite3/conn.go:167
github.com/ncruces/go-sqlite3/tests/parallel.testParallel.func2()
        /Users/cruces/Documents/Personal/go-sqlite3/tests/parallel/parallel_test.go:146 +0xc7
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/cruces/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 5053
        /Users/cruces/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
exit status 2
FAIL    github.com/ncruces/go-sqlite3/tests/parallel    4.399s
```

On:
```
goos: windows
goarch: amd64
cpu: Intel(R) Core(TM) i5-3210M CPU @ 2.50GHz
version: go1.22.0 windows/amd64
```

```
=== RUN   TestMemory
panic: wasm error: out of bounds memory access
wasm stack trace:
        .sqlite3FindTable(i32,i32,i32) i32
        .sqlite3LocateTable(i32,i32,i32,i32) i32
        .selectExpander(i32,i32) i32
        .sqlite3WalkSelect(i32,i32) i32
        .sqlite3SelectPrep(i32,i32,i32)
        .sqlite3Select(i32,i32,i32) i32
        .sqlite3RunParser(i32,i32) i32
        .sqlite3Prepare(i32,i32,i32,i32,i32,i32,i32) i32
        .sqlite3LockAndPrepare(i32,i32,i32,i32,i32,i32,i32) i32
        .sqlite3_prepare_v3(i32,i32,i32,i32,i32,i32) i32
        env.go_cur_rowid(i32,i32) i32

goroutine 5365 [running]:
github.com/ncruces/go-sqlite3.(*sqlite).call(0xc000005508, {0xfa2e71, 0x12?}, {0xc0003dde18?, 0xc0003dde08?, 0xeffeac?})
        D:/Development/GitHub/go-sqlite3/sqlite.go:181 +0x1ad
github.com/ncruces/go-sqlite3.(*Conn).PrepareFlags(0xc0003c81b0, {0xfa80ff, 0x1a}, 0x0?)
        D:/Development/GitHub/go-sqlite3/conn.go:186 +0x1be
github.com/ncruces/go-sqlite3.(*Conn).Prepare(...)
        D:/Development/GitHub/go-sqlite3/conn.go:167
github.com/ncruces/go-sqlite3/tests/parallel.testParallel.func2()
        D:/Development/GitHub/go-sqlite3/tests/parallel/parallel_test.go:146 +0xc7
golang.org/x/sync/errgroup.(*Group).Go.func1()
        D:/Apps/Go/work/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 5031
        D:/Apps/Go/work/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
exit status 2
FAIL    github.com/ncruces/go-sqlite3/tests/parallel    12.457s
```