### PR TITLE
Automatically load extensions.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -72,13 +72,9 @@ func newConn(filename string, flags OpenFlag) (conn *Conn, err error) {
 	c.arena = c.newArena(1024)
 	c.ctx = context.WithValue(c.ctx, connKey{}, c)
 	c.handle, err = c.openDB(filename, flags)
-	if err != nil {
-		return nil, err
+	if err == nil {
+		err = initExtensions(c)
 	}
-	allExtensions(func(f func(*Conn) error) bool {
-		err = f(c)
-		return err == nil
-	})
 	if err != nil {
 		return nil, err
 	}

--- a/conn.go
+++ b/conn.go
@@ -75,6 +75,13 @@ func newConn(filename string, flags OpenFlag) (conn *Conn, err error) {
 	if err != nil {
 		return nil, err
 	}
+	allExtensions(func(f func(*Conn) error) bool {
+		err = f(c)
+		return err == nil
+	})
+	if err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/ext/array/array.go
+++ b/ext/array/array.go
@@ -15,8 +15,8 @@ import (
 // The argument must be bound to a Go slice or array of
 // ints, floats, bools, strings or byte slices,
 // using [sqlite3.BindPointer] or [sqlite3.Pointer].
-func Register(db *sqlite3.Conn) {
-	sqlite3.CreateModule(db, "array", nil,
+func Register(db *sqlite3.Conn) error {
+	return sqlite3.CreateModule(db, "array", nil,
 		func(db *sqlite3.Conn, _, _, _ string, _ ...string) (array, error) {
 			err := db.DeclareVTab(`CREATE TABLE x(value, array HIDDEN)`)
 			return array{}, err

--- a/ext/array/array_test.go
+++ b/ext/array/array_test.go
@@ -133,7 +133,10 @@ func Test_array_errors(t *testing.T) {
 	}
 	defer db.Close()
 
-	array.Register(db)
+	err = array.Register(db)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = db.Exec(`SELECT * FROM array()`)
 	if err == nil {

--- a/ext/array/array_test.go
+++ b/ext/array/array_test.go
@@ -50,13 +50,13 @@ func Example_driver() {
 }
 
 func Example() {
+	sqlite3.AutoExtension(array.Register)
+
 	db, err := sqlite3.Open(":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
-
-	array.Register(db)
 
 	stmt, _, err := db.Prepare(`
 		SELECT name

--- a/ext/array/array_test.go
+++ b/ext/array/array_test.go
@@ -15,10 +15,7 @@ import (
 )
 
 func Example_driver() {
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		array.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", array.Register)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -91,10 +88,7 @@ func Example() {
 func Test_cursor_Column(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		array.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", array.Register)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/blobio/blob.go
+++ b/ext/blobio/blob.go
@@ -29,10 +29,11 @@ import (
 // along with the [sqlite3.Blob] handle.
 //
 // https://sqlite.org/c3ref/blob.html
-func Register(db *sqlite3.Conn) {
-	db.CreateFunction("readblob", 6, 0, readblob)
-	db.CreateFunction("writeblob", 6, 0, writeblob)
-	db.CreateFunction("openblob", -1, 0, openblob)
+func Register(db *sqlite3.Conn) error {
+	return errors.Join(
+		db.CreateFunction("readblob", 6, 0, readblob),
+		db.CreateFunction("writeblob", 6, 0, writeblob),
+		db.CreateFunction("openblob", -1, 0, openblob))
 }
 
 // OpenCallback is the type for the openblob callback.

--- a/ext/blobio/blob_test.go
+++ b/ext/blobio/blob_test.go
@@ -57,6 +57,11 @@ func Example() {
 	// Hello BLOB!
 }
 
+func init() {
+	sqlite3.AutoExtension(blobio.Register)
+	sqlite3.AutoExtension(array.Register)
+}
+
 func Test_readblob(t *testing.T) {
 	t.Parallel()
 
@@ -65,9 +70,6 @@ func Test_readblob(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	blobio.Register(db)
-	array.Register(db)
 
 	err = db.Exec(`SELECT readblob()`)
 	if err == nil {
@@ -125,9 +127,6 @@ func Test_openblob(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	blobio.Register(db)
-	array.Register(db)
 
 	err = db.Exec(`SELECT openblob()`)
 	if err == nil {

--- a/ext/blobio/blob_test.go
+++ b/ext/blobio/blob_test.go
@@ -18,10 +18,7 @@ import (
 
 func Example() {
 	// Open the database, registering the extension.
-	db, err := driver.Open("file:/test.db?vfs=memdb", func(conn *sqlite3.Conn) error {
-		blobio.Register(conn)
-		return nil
-	})
+	db, err := driver.Open("file:/test.db?vfs=memdb", blobio.Register)
 
 	if err != nil {
 		log.Fatal(err)

--- a/ext/bloom/bloom.go
+++ b/ext/bloom/bloom.go
@@ -20,8 +20,8 @@ import (
 // Register registers the bloom_filter virtual table:
 //
 //	CREATE VIRTUAL TABLE foo USING bloom_filter(nElements, falseProb, kHashes)
-func Register(db *sqlite3.Conn) {
-	sqlite3.CreateModule(db, "bloom_filter", create, connect)
+func Register(db *sqlite3.Conn) error {
+	return sqlite3.CreateModule(db, "bloom_filter", create, connect)
 }
 
 type bloom struct {

--- a/ext/bloom/bloom_test.go
+++ b/ext/bloom/bloom_test.go
@@ -12,6 +12,10 @@ import (
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
 )
 
+func init() {
+	sqlite3.AutoExtension(bloom.Register)
+}
+
 func TestRegister(t *testing.T) {
 	t.Parallel()
 
@@ -20,8 +24,6 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	bloom.Register(db)
 
 	err = db.Exec(`
 		CREATE VIRTUAL TABLE sports_cars USING bloom_filter(20);
@@ -89,8 +91,6 @@ func Test_compatible(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	bloom.Register(db)
 
 	query, _, err := db.Prepare(`SELECT COUNT(*) FROM plants(?)`)
 	if err != nil {

--- a/ext/csv/csv.go
+++ b/ext/csv/csv.go
@@ -23,13 +23,13 @@ import (
 
 // Register registers the CSV virtual table.
 // If a filename is specified, [os.Open] is used to open the file.
-func Register(db *sqlite3.Conn) {
-	RegisterFS(db, osutil.FS{})
+func Register(db *sqlite3.Conn) error {
+	return RegisterFS(db, osutil.FS{})
 }
 
 // RegisterFS registers the CSV virtual table.
 // If a filename is specified, fsys is used to open the file.
-func RegisterFS(db *sqlite3.Conn, fsys fs.FS) {
+func RegisterFS(db *sqlite3.Conn, fsys fs.FS) error {
 	declare := func(db *sqlite3.Conn, _, _, _ string, arg ...string) (_ *table, err error) {
 		var (
 			filename string
@@ -118,7 +118,7 @@ func RegisterFS(db *sqlite3.Conn, fsys fs.FS) {
 		return table, nil
 	}
 
-	sqlite3.CreateModule(db, "csv", declare, declare)
+	return sqlite3.CreateModule(db, "csv", declare, declare)
 }
 
 type table struct {

--- a/ext/csv/csv_test.go
+++ b/ext/csv/csv_test.go
@@ -18,7 +18,10 @@ func Example() {
 	}
 	defer db.Close()
 
-	csv.Register(db)
+	err = csv.Register(db)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	err = db.Exec(`
 		CREATE VIRTUAL TABLE eurofxref USING csv(
@@ -51,6 +54,10 @@ func Example() {
 	// On Twosday, 1€ = $1.1342
 }
 
+func init() {
+	sqlite3.AutoExtension(csv.Register)
+}
+
 func TestRegister(t *testing.T) {
 	t.Parallel()
 
@@ -59,8 +66,6 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	csv.Register(db)
 
 	const data = `
 # Comment
@@ -124,8 +129,6 @@ func TestAffinity(t *testing.T) {
 	}
 	defer db.Close()
 
-	csv.Register(db)
-
 	const data = "01\n0.10\ne"
 	err = db.Exec(`
 		CREATE VIRTUAL TABLE temp.nums USING csv(
@@ -167,8 +170,6 @@ func TestRegister_errors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	csv.Register(db)
 
 	err = db.Exec(`CREATE VIRTUAL TABLE temp.users USING csv()`)
 	if err == nil {

--- a/ext/fileio/fileio_test.go
+++ b/ext/fileio/fileio_test.go
@@ -17,10 +17,7 @@ import (
 func Test_lsmode(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		fileio.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", fileio.Register)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/fileio/fsdir_test.go
+++ b/ext/fileio/fsdir_test.go
@@ -68,7 +68,10 @@ func Test_fsdir_errors(t *testing.T) {
 	}
 	defer db.Close()
 
-	fileio.Register(db)
+	err = fileio.Register(db)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	err = db.Exec(`SELECT name FROM fsdir()`)
 	if err == nil {

--- a/ext/fileio/write_test.go
+++ b/ext/fileio/write_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ncruces/go-sqlite3"
 	"github.com/ncruces/go-sqlite3/driver"
 	_ "github.com/ncruces/go-sqlite3/embed"
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
@@ -16,10 +15,7 @@ import (
 func Test_writefile(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", Register)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/hash/hash.go
+++ b/ext/hash/hash.go
@@ -21,47 +21,60 @@ package hash
 
 import (
 	"crypto"
+	"errors"
 
 	"github.com/ncruces/go-sqlite3"
+	"github.com/ncruces/go-sqlite3/internal/util"
 )
 
 // Register registers cryptographic hash functions for a database connection.
-func Register(db *sqlite3.Conn) {
+func Register(db *sqlite3.Conn) error {
 	flags := sqlite3.DETERMINISTIC | sqlite3.INNOCUOUS
 
+	var errs util.ErrorJoiner
 	if crypto.MD4.Available() {
-		db.CreateFunction("md4", 1, flags, md4Func)
+		errs.Join(
+			db.CreateFunction("md4", 1, flags, md4Func))
 	}
 	if crypto.MD5.Available() {
-		db.CreateFunction("md5", 1, flags, md5Func)
+		errs.Join(
+			db.CreateFunction("md5", 1, flags, md5Func))
 	}
 	if crypto.SHA1.Available() {
-		db.CreateFunction("sha1", 1, flags, sha1Func)
+		errs.Join(
+			db.CreateFunction("sha1", 1, flags, sha1Func))
 	}
 	if crypto.SHA3_512.Available() {
-		db.CreateFunction("sha3", 1, flags, sha3Func)
-		db.CreateFunction("sha3", 2, flags, sha3Func)
+		errs.Join(
+			db.CreateFunction("sha3", 1, flags, sha3Func),
+			db.CreateFunction("sha3", 2, flags, sha3Func))
 	}
 	if crypto.SHA256.Available() {
-		db.CreateFunction("sha224", 1, flags, sha224Func)
-		db.CreateFunction("sha256", 1, flags, sha256Func)
-		db.CreateFunction("sha256", 2, flags, sha256Func)
+		errs.Join(
+			db.CreateFunction("sha224", 1, flags, sha224Func),
+			db.CreateFunction("sha256", 1, flags, sha256Func),
+			db.CreateFunction("sha256", 2, flags, sha256Func))
 	}
 	if crypto.SHA512.Available() {
-		db.CreateFunction("sha384", 1, flags, sha384Func)
-		db.CreateFunction("sha512", 1, flags, sha512Func)
-		db.CreateFunction("sha512", 2, flags, sha512Func)
+		errs.Join(
+			db.CreateFunction("sha384", 1, flags, sha384Func),
+			db.CreateFunction("sha512", 1, flags, sha512Func),
+			db.CreateFunction("sha512", 2, flags, sha512Func))
 	}
 	if crypto.BLAKE2s_256.Available() {
-		db.CreateFunction("blake2s", 1, flags, blake2sFunc)
+		errs.Join(
+			db.CreateFunction("blake2s", 1, flags, blake2sFunc))
 	}
 	if crypto.BLAKE2b_512.Available() {
-		db.CreateFunction("blake2b", 1, flags, blake2bFunc)
-		db.CreateFunction("blake2b", 2, flags, blake2bFunc)
+		errs.Join(
+			db.CreateFunction("blake2b", 1, flags, blake2bFunc),
+			db.CreateFunction("blake2b", 2, flags, blake2bFunc))
 	}
 	if crypto.RIPEMD160.Available() {
-		db.CreateFunction("ripemd160", 1, flags, ripemd160Func)
+		errs.Join(
+			db.CreateFunction("ripemd160", 1, flags, ripemd160Func))
 	}
+	return errors.Join(errs...)
 }
 
 func md4Func(ctx sqlite3.Context, arg ...sqlite3.Value) {

--- a/ext/hash/hash_test.go
+++ b/ext/hash/hash_test.go
@@ -7,7 +7,6 @@ import (
 	_ "crypto/sha512"
 	"testing"
 
-	"github.com/ncruces/go-sqlite3"
 	"github.com/ncruces/go-sqlite3/driver"
 	_ "github.com/ncruces/go-sqlite3/embed"
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
@@ -53,10 +52,7 @@ func TestRegister(t *testing.T) {
 		{"blake2b('', 256)", "0E5751C026E543B2E8AB2EB06099DAA1D1E5DF47778F7787FAAB45CDF12FE3A8"},
 	}
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", Register)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/lines/lines_test.go
+++ b/ext/lines/lines_test.go
@@ -18,10 +18,7 @@ import (
 )
 
 func Example() {
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		lines.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", lines.Register)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -70,10 +67,7 @@ func Example() {
 func Test_lines(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		lines.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", lines.Register)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -103,10 +97,7 @@ func Test_lines(t *testing.T) {
 func Test_lines_error(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		lines.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", lines.Register)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -130,10 +121,7 @@ func Test_lines_error(t *testing.T) {
 func Test_lines_read(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		lines.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", lines.Register)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -164,10 +152,7 @@ func Test_lines_read(t *testing.T) {
 func Test_lines_test(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		lines.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", lines.Register)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/ext/pivot/pivot.go
+++ b/ext/pivot/pivot.go
@@ -13,8 +13,8 @@ import (
 )
 
 // Register registers the pivot virtual table.
-func Register(db *sqlite3.Conn) {
-	sqlite3.CreateModule(db, "pivot", declare, declare)
+func Register(db *sqlite3.Conn) error {
+	return sqlite3.CreateModule(db, "pivot", declare, declare)
 }
 
 type table struct {

--- a/ext/pivot/pivot_test.go
+++ b/ext/pivot/pivot_test.go
@@ -14,13 +14,13 @@ import (
 
 // https://antonz.org/sqlite-pivot-table/
 func Example() {
+	sqlite3.AutoExtension(pivot.Register)
+
 	db, err := sqlite3.Open(":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
-
-	pivot.Register(db)
 
 	err = db.Exec(`
 		CREATE TABLE sales(product TEXT, year INT, income DECIMAL);

--- a/ext/pivot/pivot_test.go
+++ b/ext/pivot/pivot_test.go
@@ -83,6 +83,10 @@ func Example() {
 	// gamma   80      75      78      80
 }
 
+func init() {
+	sqlite3.AutoExtension(pivot.Register)
+}
+
 func TestRegister(t *testing.T) {
 	t.Parallel()
 
@@ -91,8 +95,6 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	pivot.Register(db)
 
 	err = db.Exec(`
 		CREATE TABLE r AS
@@ -152,8 +154,6 @@ func TestRegister_errors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	pivot.Register(db)
 
 	err = db.Exec(`CREATE VIRTUAL TABLE pivot USING pivot()`)
 	if err == nil {

--- a/ext/regexp/regexp.go
+++ b/ext/regexp/regexp.go
@@ -12,19 +12,20 @@
 package regexp
 
 import (
+	"errors"
 	"regexp"
 
 	"github.com/ncruces/go-sqlite3"
 )
 
 // Register registers Unicode aware functions for a database connection.
-func Register(db *sqlite3.Conn) {
+func Register(db *sqlite3.Conn) error {
 	flags := sqlite3.DETERMINISTIC | sqlite3.INNOCUOUS
-
-	db.CreateFunction("regexp", 2, flags, regex)
-	db.CreateFunction("regexp_like", 2, flags, regexLike)
-	db.CreateFunction("regexp_substr", 2, flags, regexSubstr)
-	db.CreateFunction("regexp_replace", 3, flags, regexReplace)
+	return errors.Join(
+		db.CreateFunction("regexp", 2, flags, regex),
+		db.CreateFunction("regexp_like", 2, flags, regexLike),
+		db.CreateFunction("regexp_substr", 2, flags, regexSubstr),
+		db.CreateFunction("regexp_replace", 3, flags, regexReplace))
 }
 
 func load(ctx sqlite3.Context, i int, expr string) (*regexp.Regexp, error) {

--- a/ext/regexp/regexp_test.go
+++ b/ext/regexp/regexp_test.go
@@ -3,7 +3,6 @@ package regexp
 import (
 	"testing"
 
-	"github.com/ncruces/go-sqlite3"
 	"github.com/ncruces/go-sqlite3/driver"
 	_ "github.com/ncruces/go-sqlite3/embed"
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
@@ -12,10 +11,7 @@ import (
 func TestRegister(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(conn *sqlite3.Conn) error {
-		Register(conn)
-		return nil
-	})
+	db, err := driver.Open(":memory:", Register)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,10 +46,7 @@ func TestRegister(t *testing.T) {
 func TestRegister_errors(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(conn *sqlite3.Conn) error {
-		Register(conn)
-		return nil
-	})
+	db, err := driver.Open(":memory:", Register)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/statement/stmt.go
+++ b/ext/statement/stmt.go
@@ -17,8 +17,8 @@ import (
 )
 
 // Register registers the statement virtual table.
-func Register(db *sqlite3.Conn) {
-	sqlite3.CreateModule(db, "statement", declare, declare)
+func Register(db *sqlite3.Conn) error {
+	return sqlite3.CreateModule(db, "statement", declare, declare)
 }
 
 type table struct {

--- a/ext/statement/stmt_test.go
+++ b/ext/statement/stmt_test.go
@@ -48,6 +48,10 @@ func Example() {
 	// Twosday was 2022-2-22
 }
 
+func init() {
+	sqlite3.AutoExtension(statement.Register)
+}
+
 func TestRegister(t *testing.T) {
 	t.Parallel()
 
@@ -56,8 +60,6 @@ func TestRegister(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	statement.Register(db)
 
 	err = db.Exec(`
 		CREATE VIRTUAL TABLE arguments USING statement((SELECT ? AS a, ? AS b, ? AS c))
@@ -106,8 +108,6 @@ func TestRegister_errors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	statement.Register(db)
 
 	err = db.Exec(`CREATE VIRTUAL TABLE split_date USING statement()`)
 	if err == nil {

--- a/ext/statement/stmt_test.go
+++ b/ext/statement/stmt_test.go
@@ -12,13 +12,13 @@ import (
 )
 
 func Example() {
+	sqlite3.AutoExtension(statement.Register)
+
 	db, err := sqlite3.Open(":memory:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
-
-	statement.Register(db)
 
 	err = db.Exec(`
 		CREATE VIRTUAL TABLE split_date USING statement((

--- a/ext/stats/boolean_test.go
+++ b/ext/stats/boolean_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ncruces/go-sqlite3"
 	_ "github.com/ncruces/go-sqlite3/embed"
-	"github.com/ncruces/go-sqlite3/ext/stats"
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
 )
 
@@ -17,8 +16,6 @@ func TestRegister_boolean(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	stats.Register(db)
 
 	err = db.Exec(`CREATE TABLE data (x)`)
 	if err != nil {

--- a/ext/stats/percentile_test.go
+++ b/ext/stats/percentile_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ncruces/go-sqlite3"
 	_ "github.com/ncruces/go-sqlite3/embed"
-	"github.com/ncruces/go-sqlite3/ext/stats"
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
 )
 
@@ -18,8 +17,6 @@ func TestRegister_percentile(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	stats.Register(db)
 
 	err = db.Exec(`CREATE TABLE data (x)`)
 	if err != nil {

--- a/ext/stats/stats.go
+++ b/ext/stats/stats.go
@@ -44,33 +44,38 @@
 // [ANSI SQL Aggregate Functions]: https://www.oreilly.com/library/view/sql-in-a/9780596155322/ch04s02.html
 package stats
 
-import "github.com/ncruces/go-sqlite3"
+import (
+	"errors"
+
+	"github.com/ncruces/go-sqlite3"
+)
 
 // Register registers statistics functions.
-func Register(db *sqlite3.Conn) {
+func Register(db *sqlite3.Conn) error {
 	flags := sqlite3.DETERMINISTIC | sqlite3.INNOCUOUS
-	db.CreateWindowFunction("var_pop", 1, flags, newVariance(var_pop))
-	db.CreateWindowFunction("var_samp", 1, flags, newVariance(var_samp))
-	db.CreateWindowFunction("stddev_pop", 1, flags, newVariance(stddev_pop))
-	db.CreateWindowFunction("stddev_samp", 1, flags, newVariance(stddev_samp))
-	db.CreateWindowFunction("covar_pop", 2, flags, newCovariance(var_pop))
-	db.CreateWindowFunction("covar_samp", 2, flags, newCovariance(var_samp))
-	db.CreateWindowFunction("corr", 2, flags, newCovariance(corr))
-	db.CreateWindowFunction("regr_r2", 2, flags, newCovariance(regr_r2))
-	db.CreateWindowFunction("regr_sxx", 2, flags, newCovariance(regr_sxx))
-	db.CreateWindowFunction("regr_syy", 2, flags, newCovariance(regr_syy))
-	db.CreateWindowFunction("regr_sxy", 2, flags, newCovariance(regr_sxy))
-	db.CreateWindowFunction("regr_avgx", 2, flags, newCovariance(regr_avgx))
-	db.CreateWindowFunction("regr_avgy", 2, flags, newCovariance(regr_avgy))
-	db.CreateWindowFunction("regr_slope", 2, flags, newCovariance(regr_slope))
-	db.CreateWindowFunction("regr_intercept", 2, flags, newCovariance(regr_intercept))
-	db.CreateWindowFunction("regr_count", 2, flags, newCovariance(regr_count))
-	db.CreateWindowFunction("regr_json", 2, flags, newCovariance(regr_json))
-	db.CreateWindowFunction("median", 1, flags, newPercentile(median))
-	db.CreateWindowFunction("percentile_cont", 2, flags, newPercentile(percentile_cont))
-	db.CreateWindowFunction("percentile_disc", 2, flags, newPercentile(percentile_disc))
-	db.CreateWindowFunction("every", 1, flags, newBoolean(every))
-	db.CreateWindowFunction("some", 1, flags, newBoolean(some))
+	return errors.Join(
+		db.CreateWindowFunction("var_pop", 1, flags, newVariance(var_pop)),
+		db.CreateWindowFunction("var_samp", 1, flags, newVariance(var_samp)),
+		db.CreateWindowFunction("stddev_pop", 1, flags, newVariance(stddev_pop)),
+		db.CreateWindowFunction("stddev_samp", 1, flags, newVariance(stddev_samp)),
+		db.CreateWindowFunction("covar_pop", 2, flags, newCovariance(var_pop)),
+		db.CreateWindowFunction("covar_samp", 2, flags, newCovariance(var_samp)),
+		db.CreateWindowFunction("corr", 2, flags, newCovariance(corr)),
+		db.CreateWindowFunction("regr_r2", 2, flags, newCovariance(regr_r2)),
+		db.CreateWindowFunction("regr_sxx", 2, flags, newCovariance(regr_sxx)),
+		db.CreateWindowFunction("regr_syy", 2, flags, newCovariance(regr_syy)),
+		db.CreateWindowFunction("regr_sxy", 2, flags, newCovariance(regr_sxy)),
+		db.CreateWindowFunction("regr_avgx", 2, flags, newCovariance(regr_avgx)),
+		db.CreateWindowFunction("regr_avgy", 2, flags, newCovariance(regr_avgy)),
+		db.CreateWindowFunction("regr_slope", 2, flags, newCovariance(regr_slope)),
+		db.CreateWindowFunction("regr_intercept", 2, flags, newCovariance(regr_intercept)),
+		db.CreateWindowFunction("regr_count", 2, flags, newCovariance(regr_count)),
+		db.CreateWindowFunction("regr_json", 2, flags, newCovariance(regr_json)),
+		db.CreateWindowFunction("median", 1, flags, newPercentile(median)),
+		db.CreateWindowFunction("percentile_cont", 2, flags, newPercentile(percentile_cont)),
+		db.CreateWindowFunction("percentile_disc", 2, flags, newPercentile(percentile_disc)),
+		db.CreateWindowFunction("every", 1, flags, newBoolean(every)),
+		db.CreateWindowFunction("some", 1, flags, newBoolean(some)))
 }
 
 const (

--- a/ext/stats/stats_test.go
+++ b/ext/stats/stats_test.go
@@ -10,6 +10,10 @@ import (
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
 )
 
+func init() {
+	sqlite3.AutoExtension(stats.Register)
+}
+
 func TestRegister_variance(t *testing.T) {
 	t.Parallel()
 
@@ -18,8 +22,6 @@ func TestRegister_variance(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	stats.Register(db)
 
 	err = db.Exec(`CREATE TABLE data (x)`)
 	if err != nil {
@@ -87,8 +89,6 @@ func TestRegister_covariance(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-
-	stats.Register(db)
 
 	err = db.Exec(`CREATE TABLE data (y, x)`)
 	if err != nil {
@@ -216,8 +216,6 @@ func Benchmark_variance(b *testing.B) {
 		b.Fatal(err)
 	}
 	defer db.Close()
-
-	stats.Register(db)
 
 	stmt, _, err := db.Prepare(`SELECT var_pop(value) FROM generate_series(0, ?)`)
 	if err != nil {

--- a/ext/uuid/uuid.go
+++ b/ext/uuid/uuid.go
@@ -5,6 +5,7 @@ package uuid
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -25,14 +26,15 @@ import (
 //	uuid_blob(u)
 //
 // Converts a UUID into a 16-byte blob.
-func Register(db *sqlite3.Conn) {
+func Register(db *sqlite3.Conn) error {
 	flags := sqlite3.DETERMINISTIC | sqlite3.INNOCUOUS
-	db.CreateFunction("uuid", 0, sqlite3.INNOCUOUS, generate)
-	db.CreateFunction("uuid", 1, sqlite3.INNOCUOUS, generate)
-	db.CreateFunction("uuid", 2, sqlite3.INNOCUOUS, generate)
-	db.CreateFunction("uuid", 3, sqlite3.INNOCUOUS, generate)
-	db.CreateFunction("uuid_str", 1, flags, toString)
-	db.CreateFunction("uuid_blob", 1, flags, toBLOB)
+	return errors.Join(
+		db.CreateFunction("uuid", 0, sqlite3.INNOCUOUS, generate),
+		db.CreateFunction("uuid", 1, sqlite3.INNOCUOUS, generate),
+		db.CreateFunction("uuid", 2, sqlite3.INNOCUOUS, generate),
+		db.CreateFunction("uuid", 3, sqlite3.INNOCUOUS, generate),
+		db.CreateFunction("uuid_str", 1, flags, toString),
+		db.CreateFunction("uuid_blob", 1, flags, toBlob))
 }
 
 func generate(ctx sqlite3.Context, arg ...sqlite3.Value) {
@@ -147,7 +149,7 @@ func fromValue(arg sqlite3.Value) (u uuid.UUID, err error) {
 	return u, err
 }
 
-func toBLOB(ctx sqlite3.Context, arg ...sqlite3.Value) {
+func toBlob(ctx sqlite3.Context, arg ...sqlite3.Value) {
 	u, err := fromValue(arg[0])
 	if err != nil {
 		ctx.ResultError(err)

--- a/ext/uuid/uuid_test.go
+++ b/ext/uuid/uuid_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/ncruces/go-sqlite3"
 	"github.com/ncruces/go-sqlite3/driver"
 	_ "github.com/ncruces/go-sqlite3/embed"
 	_ "github.com/ncruces/go-sqlite3/internal/testcfg"
@@ -13,10 +12,7 @@ import (
 func Test_generate(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(conn *sqlite3.Conn) error {
-		Register(conn)
-		return nil
-	})
+	db, err := driver.Open(":memory:", Register)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,10 +131,7 @@ func Test_generate(t *testing.T) {
 func Test_convert(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(conn *sqlite3.Conn) error {
-		Register(conn)
-		return nil
-	})
+	db, err := driver.Open(":memory:", Register)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/ext/zorder/zorder.go
+++ b/ext/zorder/zorder.go
@@ -4,15 +4,18 @@
 package zorder
 
 import (
+	"errors"
+
 	"github.com/ncruces/go-sqlite3"
 	"github.com/ncruces/go-sqlite3/internal/util"
 )
 
 // Register registers the zorder and unzorder SQL functions.
-func Register(db *sqlite3.Conn) {
+func Register(db *sqlite3.Conn) error {
 	flags := sqlite3.DETERMINISTIC | sqlite3.INNOCUOUS
-	db.CreateFunction("zorder", -1, flags, zorder)
-	db.CreateFunction("unzorder", 3, flags, unzorder)
+	return errors.Join(
+		db.CreateFunction("zorder", -1, flags, zorder),
+		db.CreateFunction("unzorder", 3, flags, unzorder))
 }
 
 func zorder(ctx sqlite3.Context, arg ...sqlite3.Value) {

--- a/ext/zorder/zorder_test.go
+++ b/ext/zorder/zorder_test.go
@@ -3,7 +3,6 @@ package zorder_test
 import (
 	"testing"
 
-	"github.com/ncruces/go-sqlite3"
 	"github.com/ncruces/go-sqlite3/driver"
 	_ "github.com/ncruces/go-sqlite3/embed"
 	"github.com/ncruces/go-sqlite3/ext/zorder"
@@ -13,10 +12,7 @@ import (
 func TestRegister_zorder(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		zorder.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", zorder.Register)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,10 +56,7 @@ func TestRegister_zorder(t *testing.T) {
 func TestRegister_unzorder(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		zorder.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", zorder.Register)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -90,10 +83,7 @@ func TestRegister_unzorder(t *testing.T) {
 func TestRegister_error(t *testing.T) {
 	t.Parallel()
 
-	db, err := driver.Open(":memory:", func(c *sqlite3.Conn) error {
-		zorder.Register(c)
-		return nil
-	})
+	db, err := driver.Open(":memory:", zorder.Register)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/func.go
+++ b/func.go
@@ -31,8 +31,9 @@ func (c *Conn) CollationNeeded(cb func(db *Conn, name string)) error {
 //
 // This can be used to load schemas that contain
 // one or more unknown collating sequences.
-func (c *Conn) AnyCollationNeeded() {
-	c.call("sqlite3_anycollseq_init", uint64(c.handle), 0, 0)
+func (c Conn) AnyCollationNeeded() error {
+	r := c.call("sqlite3_anycollseq_init", uint64(c.handle), 0, 0)
+	return c.error(r)
 }
 
 // CreateCollation defines a new collating sequence.

--- a/internal/util/error.go
+++ b/internal/util/error.go
@@ -104,3 +104,13 @@ func ErrorCodeString(rc uint32) string {
 	}
 	return "sqlite3: unknown error"
 }
+
+type ErrorJoiner []error
+
+func (j *ErrorJoiner) Join(errs ...error) {
+	for _, err := range errs {
+		if err != nil {
+			*j = append(*j, err)
+		}
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,29 @@
+package sqlite3
+
+import "sync"
+
+var (
+	// +checklocks:extRegistryMtx
+	extRegistry    []func(*Conn) error
+	extRegistryMtx sync.RWMutex
+)
+
+// AutoExtension causes the entryPoint function to be invoked
+// for each new database connection that is created.
+//
+// https://sqlite.org/c3ref/auto_extension.html
+func AutoExtension(entryPoint func(*Conn) error) {
+	extRegistryMtx.Lock()
+	defer extRegistryMtx.Unlock()
+	extRegistry = append(extRegistry, entryPoint)
+}
+
+func allExtensions(yield func(func(*Conn) error) bool) {
+	extRegistryMtx.RLock()
+	defer extRegistryMtx.RUnlock()
+	for _, ext := range extRegistry {
+		if !yield(ext) {
+			return
+		}
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -18,12 +18,13 @@ func AutoExtension(entryPoint func(*Conn) error) {
 	extRegistry = append(extRegistry, entryPoint)
 }
 
-func allExtensions(yield func(func(*Conn) error) bool) {
+func initExtensions(c *Conn) error {
 	extRegistryMtx.RLock()
 	defer extRegistryMtx.RUnlock()
-	for _, ext := range extRegistry {
-		if !yield(ext) {
-			return
+	for _, f := range extRegistry {
+		if err := f(c); err != nil {
+			return err
 		}
 	}
+	return nil
 }

--- a/tests/func_test.go
+++ b/tests/func_test.go
@@ -207,7 +207,10 @@ func TestAnyCollationNeeded(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	db.AnyCollationNeeded()
+	err = db.AnyCollationNeeded()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	stmt, _, err := db.Prepare(`SELECT id, name FROM users ORDER BY name COLLATE silly`)
 	if err != nil {


### PR DESCRIPTION
https://sqlite.org/c3ref/auto_extension.html

As a first step, refactor `Register` functions that were having errors ignored.
This is a minor API breakage.