### PR TITLE
Add example for custom time with database/sql

### DIFF
--- a/context.go
+++ b/context.go
@@ -130,7 +130,8 @@ func (ctx Context) ResultNull() {
 //
 // https://sqlite.org/c3ref/result_blob.html
 func (ctx Context) ResultTime(value time.Time, format TimeFormat) {
-	if format == TimeFormatDefault {
+	switch format {
+	case TimeFormatDefault, TimeFormatAuto, time.RFC3339Nano:
 		ctx.resultRFC3339Nano(value)
 		return
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -31,18 +31,27 @@
 //   - "sqlite" encodes as SQLite and decodes any [format] supported by SQLite;
 //   - "rfc3339" encodes and decodes RFC 3339 only.
 //
+// If you encode as RFC 3339 (the default),
+// consider using the TIME [collating sequence] to produce a time-ordered sequence.
+//
+// To scan values in other formats, [sqlite3.TimeFormat.Scanner] may be helpful.
+// To bind values in other formats, [sqlite3.TimeFormat.Encode] them before binding.
+//
 // When using a custom time struct, you'll have to implement
-// [database/sql/driver.Valuer] and [database/sql.Scanner]. The Value method
-// should serialise to a time format this driver recognises, like [time.RFC3339]
-// or [time.RFC3339Nano].
+// [database/sql/driver.Valuer] and [database/sql.Scanner].
 //
-// The Scan method needs to take into account that the value it receives can
-// be of differing types. It can be a [time.Time] if the driver knows to decode
-// a column as such and manages to do so successfully, but can also be a string,
-// a byte, an integer etc. depending on the column type and what whoever wrote
-// to the column put in there.
+// The Value method should ideally serialise to a time [format] supported by SQLite.
+// This ensures SQL date and time functions work as they should,
+// and that your schema works with other SQLite tools.
+// [sqlite3.TimeFormat.Encode] may help.
 //
-// # Setting PRAGMA's
+// The Scan method needs to take into account that the value it receives can be of differing types.
+// It can already be a [time.Time], if the driver decoded the value according to "_timefmt" rules.
+// Or it can be a: string, int64, float64, []byte, nil,
+// depending on the column type and what whoever wrote the value.
+// [sqlite3.TimeFormat.Decode] may help.
+//
+// # Setting PRAGMAs
 //
 // [PRAGMA] statements can be specified using "_pragma":
 //
@@ -51,7 +60,8 @@
 // If no PRAGMAs are specified, a busy timeout of 1 minute is set.
 //
 // Order matters:
-// busy timeout and locking mode should be the first PRAGMAs set, in that order.
+// encryption keys, busy timeout and locking mode should be the first PRAGMAs set,
+// in that order.
 //
 // [URI]: https://sqlite.org/uri.html
 // [PRAGMA]: https://sqlite.org/pragma.html
@@ -60,6 +70,7 @@
 // [serializable]: https://pkg.go.dev/database/sql#TxOptions
 // [read-only]: https://pkg.go.dev/database/sql#TxOptions
 // [format]: https://sqlite.org/lang_datefunc.html#time_values
+// [collating sequence]: https://sqlite.org/datatype3.html#collating_sequences
 package driver
 
 import (

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -612,7 +612,8 @@ func (r *rows) Next(dest []driver.Value) error {
 }
 
 func (r *rows) decodeTime(i int, v any) (_ time.Time, ok bool) {
-	if r.tmRead == sqlite3.TimeFormatDefault {
+	switch r.tmRead {
+	case sqlite3.TimeFormatDefault, time.RFC3339Nano:
 		// handled by maybeTime
 		return
 	}

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -8,6 +8,8 @@
 //
 // The data source name for "sqlite3" databases can be a filename or a "file:" [URI].
 //
+// # Default transaction mode
+//
 // The [TRANSACTION] mode can be specified using "_txlock":
 //
 //	sql.Open("sqlite3", "file:demo.db?_txlock=immediate")
@@ -18,6 +20,8 @@
 //   - a [serializable] transaction is always "immediate";
 //   - a [read-only] transaction is always "deferred".
 //
+// # Working with time
+//
 // The time encoding/decoding format can be specified using "_timefmt":
 //
 //	sql.Open("sqlite3", "file:demo.db?_timefmt=sqlite")
@@ -26,6 +30,19 @@
 //   - "auto" encodes as RFC 3339 and decodes any [format] supported by SQLite;
 //   - "sqlite" encodes as SQLite and decodes any [format] supported by SQLite;
 //   - "rfc3339" encodes and decodes RFC 3339 only.
+//
+// When using a custom time struct, you'll have to implement
+// [database/sql/driver.Valuer] and [database/sql.Scanner]. The Value method
+// should serialise to a time format this driver recognises, like [time.RFC3339]
+// or [time.RFC3339Nano].
+//
+// The Scan method needs to take into account that the value it receives can
+// be of differing types. It can be a [time.Time] if the driver knows to decode
+// a column as such and manages to do so successfully, but can also be a string,
+// a byte, an integer etc. depending on the column type and what whoever wrote
+// to the column put in there.
+//
+// # Setting PRAGMA's
 //
 // [PRAGMA] statements can be specified using "_pragma":
 //

--- a/driver/example_test.go
+++ b/driver/example_test.go
@@ -154,34 +154,34 @@ func addAlbum(alb Album) (int64, error) {
 }
 
 func Example_customTime() {
-	// Get a database handle.
 	db, err := sql.Open("sqlite3", "file:/time.db?vfs=memdb")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer db.Close()
 
-	// Create a table to hold our data
-	_, err = db.Exec(`CREATE TABLE data (
-		id INTEGER PRIMARY KEY,
-		date_time TEXT
-		) STRICT`)
+	_, err = db.Exec(`
+		CREATE TABLE data (
+			id INTEGER PRIMARY KEY,
+			date_time TEXT
+		) STRICT;
+	`)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Initialise our custom time
+	// Initialise our custom time.
 	c := CustomTime{time.Date(
 		2009, 11, 17, 20, 34, 58, 651387237, time.UTC)}
 
-	// Store our custom time in the DB
+	// Store our custom time in the database.
 	_, err = db.Exec(`INSERT INTO data (date_time) VALUES(?)`, c)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	var strTime string
-	// Retrieve it as a string, the result of Value()
+	// Retrieve it as a string, the result of Value().
 	err = db.QueryRow(`
 		SELECT date_time
 		FROM data
@@ -193,7 +193,7 @@ func Example_customTime() {
 	fmt.Println(strTime)
 
 	var resTime CustomTime
-	// Retrieve it as our custom time type, going through Scan()
+	// Retrieve it as our custom time type, going through Scan().
 	err = db.QueryRow(`
 		SELECT date_time
 		FROM data

--- a/driver/example_test.go
+++ b/driver/example_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/ncruces/go-sqlite3"
 	_ "github.com/ncruces/go-sqlite3/driver"
 	_ "github.com/ncruces/go-sqlite3/embed"
 	_ "github.com/ncruces/go-sqlite3/vfs/memdb"
@@ -253,12 +254,10 @@ func Example_customTime() {
 	// custom time: 2009-11-17 20:34:58.651 +0000 UTC
 }
 
-var Layout = "2006-01-02T15:04:05.000Z07:00"
-
 type CustomTime struct{ time.Time }
 
 func (c CustomTime) Value() (driver.Value, error) {
-	return c.UTC().Format(Layout), nil
+	return sqlite3.TimeFormat7TZ.Encode(c.UTC()), nil
 }
 
 func (c *CustomTime) Scan(value any) error {
@@ -270,7 +269,7 @@ func (c *CustomTime) Scan(value any) error {
 		*c = CustomTime{v}
 	case string:
 		fmt.Println("scan type string:", v)
-		t, err := time.Parse(Layout, v)
+		t, err := sqlite3.TimeFormat7TZ.Decode(v)
 		if err != nil {
 			return err
 		}

--- a/driver/json_test.go
+++ b/driver/json_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func Example_json() {
-	db, err := driver.Open("file:/test.db?vfs=memdb")
+	db, err := driver.Open("file:/json.db?vfs=memdb")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/driver/savepoint_test.go
+++ b/driver/savepoint_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleSavepoint() {
-	db, err := driver.Open("file:/test.db?vfs=memdb")
+	db, err := driver.Open("file:/svpt.db?vfs=memdb")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.work.sum
+++ b/go.work.sum
@@ -4,5 +4,6 @@ golang.org/x/net v0.21.0/go.mod h1:bIjVDfnllIU7BJ2DNgfnXvpSvtn8VRwhlsaeUTyUS44=
 golang.org/x/term v0.20.0/go.mod h1:8UkIAJTvZgivsXaD6/pH6U9ecQzZ45awqEOzuCvwpFY=
 golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=
 golang.org/x/term v0.22.0/go.mod h1:F3qCibpT5AMpCRfhfT53vVJwhLtIVHhB9XDjfFvnMI4=
+golang.org/x/term v0.23.0/go.mod h1:DgV24QBUrK6jhZXl+20l6UWznPlwAHm1Q1mGHtydmSk=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=

--- a/stmt.go
+++ b/stmt.go
@@ -311,7 +311,8 @@ func (s *Stmt) BindNull(param int) error {
 //
 // https://sqlite.org/c3ref/bind_blob.html
 func (s *Stmt) BindTime(param int, value time.Time, format TimeFormat) error {
-	if format == TimeFormatDefault {
+	switch format {
+	case TimeFormatDefault, TimeFormatAuto, time.RFC3339Nano:
 		return s.bindRFC3339Nano(param, value)
 	}
 	switch v := format.Encode(value).(type) {


### PR DESCRIPTION
This adds an example on implementing sql.Scanner and driver.Valuer on custom time structs so they can be stored and retrieved from the database as expected.

It also adds some sections to the driver documentation to make it a bit easier to read.