### PR TITLE
add compiler hints to reduce number of slice bounds checks

### DIFF
--- a/internal/util/func.go
+++ b/internal/util/func.go
@@ -26,6 +26,7 @@ func ExportFuncVI[T0 i32](mod wazero.HostModuleBuilder, name string, fn func(con
 type funcVII[T0, T1 i32] func(context.Context, api.Module, T0, T1)
 
 func (fn funcVII[T0, T1]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[1] // prevent bounds check on every slice access
 	fn(ctx, mod, T0(stack[0]), T1(stack[1]))
 }
 
@@ -39,6 +40,7 @@ func ExportFuncVII[T0, T1 i32](mod wazero.HostModuleBuilder, name string, fn fun
 type funcVIII[T0, T1, T2 i32] func(context.Context, api.Module, T0, T1, T2)
 
 func (fn funcVIII[T0, T1, T2]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[2] // prevent bounds check on every slice access
 	fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]))
 }
 
@@ -52,6 +54,7 @@ func ExportFuncVIII[T0, T1, T2 i32](mod wazero.HostModuleBuilder, name string, f
 type funcVIIII[T0, T1, T2, T3 i32] func(context.Context, api.Module, T0, T1, T2, T3)
 
 func (fn funcVIIII[T0, T1, T2, T3]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[3] // prevent bounds check on every slice access
 	fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]), T3(stack[3]))
 }
 
@@ -65,6 +68,7 @@ func ExportFuncVIIII[T0, T1, T2, T3 i32](mod wazero.HostModuleBuilder, name stri
 type funcVIIIII[T0, T1, T2, T3, T4 i32] func(context.Context, api.Module, T0, T1, T2, T3, T4)
 
 func (fn funcVIIIII[T0, T1, T2, T3, T4]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[4] // prevent bounds check on every slice access
 	fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]), T3(stack[3]), T4(stack[4]))
 }
 
@@ -78,6 +82,7 @@ func ExportFuncVIIIII[T0, T1, T2, T3, T4 i32](mod wazero.HostModuleBuilder, name
 type funcVIIIIJ[T0, T1, T2, T3 i32, T4 i64] func(context.Context, api.Module, T0, T1, T2, T3, T4)
 
 func (fn funcVIIIIJ[T0, T1, T2, T3, T4]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[4] // prevent bounds check on every slice access
 	fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]), T3(stack[3]), T4(stack[4]))
 }
 
@@ -104,6 +109,7 @@ func ExportFuncII[TR, T0 i32](mod wazero.HostModuleBuilder, name string, fn func
 type funcIII[TR, T0, T1 i32] func(context.Context, api.Module, T0, T1) TR
 
 func (fn funcIII[TR, T0, T1]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[1] // prevent bounds check on every slice access
 	stack[0] = uint64(fn(ctx, mod, T0(stack[0]), T1(stack[1])))
 }
 
@@ -117,6 +123,7 @@ func ExportFuncIII[TR, T0, T1 i32](mod wazero.HostModuleBuilder, name string, fn
 type funcIIII[TR, T0, T1, T2 i32] func(context.Context, api.Module, T0, T1, T2) TR
 
 func (fn funcIIII[TR, T0, T1, T2]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[2] // prevent bounds check on every slice access
 	stack[0] = uint64(fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2])))
 }
 
@@ -130,6 +137,7 @@ func ExportFuncIIII[TR, T0, T1, T2 i32](mod wazero.HostModuleBuilder, name strin
 type funcIIIII[TR, T0, T1, T2, T3 i32] func(context.Context, api.Module, T0, T1, T2, T3) TR
 
 func (fn funcIIIII[TR, T0, T1, T2, T3]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[3] // prevent bounds check on every slice access
 	stack[0] = uint64(fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]), T3(stack[3])))
 }
 
@@ -143,6 +151,7 @@ func ExportFuncIIIII[TR, T0, T1, T2, T3 i32](mod wazero.HostModuleBuilder, name 
 type funcIIIIII[TR, T0, T1, T2, T3, T4 i32] func(context.Context, api.Module, T0, T1, T2, T3, T4) TR
 
 func (fn funcIIIIII[TR, T0, T1, T2, T3, T4]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[4] // prevent bounds check on every slice access
 	stack[0] = uint64(fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]), T3(stack[3]), T4(stack[4])))
 }
 
@@ -156,6 +165,7 @@ func ExportFuncIIIIII[TR, T0, T1, T2, T3, T4 i32](mod wazero.HostModuleBuilder, 
 type funcIIIIIII[TR, T0, T1, T2, T3, T4, T5 i32] func(context.Context, api.Module, T0, T1, T2, T3, T4, T5) TR
 
 func (fn funcIIIIIII[TR, T0, T1, T2, T3, T4, T5]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[5] // prevent bounds check on every slice access
 	stack[0] = uint64(fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]), T3(stack[3]), T4(stack[4]), T5(stack[5])))
 }
 
@@ -169,6 +179,7 @@ func ExportFuncIIIIIII[TR, T0, T1, T2, T3, T4, T5 i32](mod wazero.HostModuleBuil
 type funcIIIIJ[TR, T0, T1, T2 i32, T3 i64] func(context.Context, api.Module, T0, T1, T2, T3) TR
 
 func (fn funcIIIIJ[TR, T0, T1, T2, T3]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[3] // prevent bounds check on every slice access
 	stack[0] = uint64(fn(ctx, mod, T0(stack[0]), T1(stack[1]), T2(stack[2]), T3(stack[3])))
 }
 
@@ -182,6 +193,7 @@ func ExportFuncIIIIJ[TR, T0, T1, T2 i32, T3 i64](mod wazero.HostModuleBuilder, n
 type funcIIJ[TR, T0 i32, T1 i64] func(context.Context, api.Module, T0, T1) TR
 
 func (fn funcIIJ[TR, T0, T1]) Call(ctx context.Context, mod api.Module, stack []uint64) {
+	_ = stack[1] // prevent bounds check on every slice access
 	stack[0] = uint64(fn(ctx, mod, T0(stack[0]), T1(stack[1])))
 }
 

--- a/stmt.go
+++ b/stmt.go
@@ -2,6 +2,7 @@ package sqlite3
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"strconv"
 	"time"
@@ -639,6 +640,14 @@ func (s *Stmt) Columns(dest []any) error {
 	}
 
 	types := util.View(s.c.mod, typePtr, count)
+
+	// hint to the compiler that
+	// it can omit bounds check
+	// accessing types[i] below.
+	if len(types) != len(dest) {
+		return errors.New("incorrect destination count")
+	}
+
 	for i := range dest {
 		switch types[i] {
 		case byte(INTEGER):

--- a/stmt.go
+++ b/stmt.go
@@ -2,7 +2,6 @@ package sqlite3
 
 import (
 	"encoding/json"
-	"errors"
 	"math"
 	"strconv"
 	"time"
@@ -645,7 +644,7 @@ func (s *Stmt) Columns(dest []any) error {
 	// it can omit bounds check
 	// accessing types[i] below.
 	if len(types) != len(dest) {
-		return errors.New("incorrect destination count")
+		panic(util.AssertErr())
 	}
 
 	for i := range dest {


### PR DESCRIPTION
Just some quick changes that hint to the compiler expected lengths in places to reduce the number of slice bounds checks it needs to do. You can confirm before and after results by using `-gcflags="-d=ssa/check_bce/debug=1"`, or more usefully i was specifically doing `go test -gcflags="-d=ssa/check_bce/debug=1" -v 2>&1 1>/dev/null | grep $fileNameToCheck`