### PR TITLE
use "len(buf)-1" to access final slice index to eliminate a few more boundary checks

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -57,7 +57,7 @@ func Quote(value any) string {
 			buf[i] = b
 			i += 1
 		}
-		buf[i] = '\''
+		buf[len(buf)-1] = '\''
 		return unsafe.String(&buf[0], len(buf))
 
 	case []byte:
@@ -71,7 +71,7 @@ func Quote(value any) string {
 			buf[i+1] = hex[b%16]
 			i += 2
 		}
-		buf[i] = '\''
+		buf[len(buf)-1] = '\''
 		return unsafe.String(&buf[0], len(buf))
 
 	case ZeroBlob:
@@ -107,6 +107,6 @@ func QuoteIdentifier(id string) string {
 		buf[i] = b
 		i += 1
 	}
-	buf[i] = '"'
+	buf[len(buf)-1] = '"'
 	return unsafe.String(&buf[0], len(buf))
 }


### PR DESCRIPTION
Also learnt in the process that when it comes to boundary checking Go doesn't seem to trust its own allocated slice length (though I'm assuming this wasn't a choice). So any slice allocated with a variable length, even if you know it's *at least* literal `x` because the length is `x+$uintVariable`, it still performs boundary checks on all the slice indices up to `x-1` unless you put a manual check directly after the slice allocation. There were a few cases of these that could be added here, but given it's an almost pointlessly small optimization that frankly has a weird "code smell" (given you're checking the length of a slice directly after allocating it), I didn't bother including them. Though I might see if there's an issue open for it on the Go project.