### PR TITLE
Add ColumnTypeScanType supports

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -501,7 +501,7 @@ func (c *Conn) TableColumnMetadata(schema, table, column string) (declType, coll
 		uint64(declTypePtr), uint64(collSeqPtr),
 		uint64(notNullPtr), uint64(primaryKeyPtr), uint64(autoIncPtr))
 	if err = c.error(r); err == nil && column != "" {
-		declType = util.ReadString(c.mod, util.ReadUint32(c.mod, declTypePtr), _MAX_NAME)
+		declType = strings.ToUpper(util.ReadString(c.mod, util.ReadUint32(c.mod, declTypePtr), _MAX_NAME))
 		collSeq = util.ReadString(c.mod, util.ReadUint32(c.mod, collSeqPtr), _MAX_NAME)
 		notNull = util.ReadUint32(c.mod, notNullPtr) != 0
 		autoInc = util.ReadUint32(c.mod, autoIncPtr) != 0


### PR DESCRIPTION
I'm developing a Backend as a Service (BaaS) and planning to change the SQLite driver to `go-sqlite3`. However, I have encountered some challenges:

## 1. Raw Query Execution Without Knowing Column Types

Example:

```go
db.Query[T](ctx, client, "SELECT * FROM categories WHERE id = ?", 5)
```

In this case, `T` could either be a struct or an ordered map. If `T` is an ordered map, there is no way for `db.Query` to prepare the target `values` slice.

For instance:

```go
entities, err := db.Query[*entity.Entity](ctx, client, "SELECT * FROM categories WHERE id > ?", 1)
```

To resolve this, implementing the following function would help by providing the column scan types:

```go
func (r *rows) ColumnTypeScanType(index int) reflect.Type
```

## 2. Lowercase declType Causes Date Parsing Issues
The issue arises when calling `column.ScanType`. The driver invokes `rows.ColumnTypeDatabaseTypeName` and `rows.ColumnTypeNullable`. Both of these functions call `rows.loadTypes`, which retrieves the column type from the table but does not convert it to uppercase.

This results in the `decodeTime` function ignoring actual date fields.

To resolve this, uppercase the `declType` in `TableColumnMetadata`.

https://github.com/ncruces/go-sqlite3/blob/main/driver/driver.go#L693
