### PR TITLE
Fix GlobPrefix.

### DIFF
--- a/ext/regexp/regexp.go
+++ b/ext/regexp/regexp.go
@@ -59,7 +59,7 @@ func GlobPrefix(expr string) string {
 	}
 	prog, err := syntax.Compile(re.Simplify())
 	if err != nil {
-		return "" // no match possible
+		return "" // notest
 	}
 
 	i := &prog.Inst[prog.Start]
@@ -69,7 +69,7 @@ loop1:
 	for {
 		switch i.Op {
 		case syntax.InstFail:
-			return "" // no match possible
+			return "" // notest
 		case syntax.InstCapture, syntax.InstNop:
 			// skip
 		case syntax.InstEmptyWidth:
@@ -88,7 +88,7 @@ loop2:
 	for {
 		switch i.Op {
 		case syntax.InstFail:
-			return "" // no match possible
+			return "" // notest
 		case syntax.InstCapture, syntax.InstEmptyWidth, syntax.InstNop:
 			// skip
 		case syntax.InstRune, syntax.InstRune1:

--- a/ext/regexp/regexp_test.go
+++ b/ext/regexp/regexp_test.go
@@ -2,7 +2,6 @@ package regexp
 
 import (
 	"database/sql"
-	"regexp"
 	"testing"
 
 	"github.com/ncruces/go-sqlite3/driver"
@@ -108,18 +107,18 @@ func TestGlobPrefix(t *testing.T) {
 		re   string
 		want string
 	}{
-		{``, ""},
-		{`a`, "a"},
-		{`a*`, "*"},
-		{`a+`, "a*"},
-		{`ab*`, "a*"},
-		{`ab+`, "ab*"},
-		{`a\?b`, "a*"},
+		{``, "*"},
+		{`^a`, "a*"},
+		{`^a*`, "*"},
+		{`^a+`, "a*"},
+		{`^ab*`, "a*"},
+		{`^ab+`, "ab*"},
+		{`^a\?b`, "a*"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.re, func(t *testing.T) {
-			if got := GlobPrefix(regexp.MustCompile(tt.re)); got != tt.want {
-				t.Errorf("GlobPrefix() = %v, want %v", got, tt.want)
+			if got := GlobPrefix(tt.re); got != tt.want {
+				t.Errorf("GlobPrefix(%v) = %v, want %v", tt.re, got, tt.want)
 			}
 		})
 	}

--- a/ext/regexp/regexp_test.go
+++ b/ext/regexp/regexp_test.go
@@ -2,6 +2,8 @@ package regexp
 
 import (
 	"database/sql"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/ncruces/go-sqlite3/driver"
@@ -107,13 +109,18 @@ func TestGlobPrefix(t *testing.T) {
 		re   string
 		want string
 	}{
+		{`[`, ""},
 		{``, "*"},
+		{`^`, "*"},
+		{`a`, "*"},
+		{`ab`, "*"},
 		{`^a`, "a*"},
 		{`^a*`, "*"},
 		{`^a+`, "a*"},
 		{`^ab*`, "a*"},
 		{`^ab+`, "ab*"},
 		{`^a\?b`, "a*"},
+		{`^[a-z]`, "*"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.re, func(t *testing.T) {
@@ -122,4 +129,35 @@ func TestGlobPrefix(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzGlobPrefix(f *testing.F) {
+	f.Add(``, ``)
+	f.Add(`[`, ``)
+	f.Add(`^`, ``)
+	f.Add(`a`, `a`)
+	f.Add(`ab`, `b`)
+	f.Add(`^a`, `a`)
+	f.Add(`^a*`, `ab`)
+	f.Add(`^a+`, `ab`)
+	f.Add(`^ab*`, `ab`)
+	f.Add(`^ab+`, `ab`)
+	f.Add(`^a\?b`, `ab`)
+	f.Add(`^[a-z]`, `ab`)
+
+	f.Fuzz(func(t *testing.T, lit, str string) {
+		re, err := regexp.Compile(lit)
+		if err != nil {
+			t.SkipNow()
+		}
+		if re.MatchString(str) {
+			prefix, ok := strings.CutSuffix(GlobPrefix(lit), "*")
+			if !ok {
+				t.Fatalf("missing * after %q for %q with %q", prefix, lit, str)
+			}
+			if !strings.HasPrefix(str, prefix) {
+				t.Fatalf("missing prefix %q for %q with %q", prefix, lit, str)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Due to a misunderstanding from my part, `GlobPrefix` would happily return a literal prefix that must start any match, but would not take care to anchor that match at the start of the string, which made it unsuitable to take advantage of the LIKE optimization, and just wrong.

Unfortunately package `regexp` does not offer a suitable API for this; had to use `syntax/regexp` instead.
Significant fuzzing went into validating the solution.

This is a breaking API change.