### PR TITLE
Call AggregateSeqFunction for empty input groups

### DIFF
--- a/func.go
+++ b/func.go
@@ -85,7 +85,7 @@ func (c *Conn) CreateAggregateFunction(name string, nArg int, flag FunctionFlag,
 	namePtr := c.arena.String(name)
 	if fn != nil {
 		funcPtr = c.wrp.AddHandle(AggregateConstructor(func() AggregateFunction {
-			var a aggregateFunc
+			a := aggregateFunc{fn: fn}
 			coro := func(yieldCoro func(struct{}) bool) {
 				seq := func(yieldSeq func([]Value) bool) {
 					for yieldSeq(a.arg) {
@@ -279,15 +279,18 @@ func returnArgs(p *[]Value) {
 }
 
 type aggregateFunc struct {
-	next func() (struct{}, bool)
-	stop func()
-	ctx  Context
-	arg  []Value
+	next    func() (struct{}, bool)
+	stop    func()
+	fn      AggregateSeqFunction
+	ctx     Context
+	arg     []Value
+	stepped bool
 }
 
 func (a *aggregateFunc) Step(ctx Context, arg ...Value) {
 	a.ctx = ctx
 	a.arg = append(a.arg[:0], arg...)
+	a.stepped = true
 	if _, more := a.next(); !more {
 		a.stop()
 	}
@@ -295,6 +298,16 @@ func (a *aggregateFunc) Step(ctx Context, arg ...Value) {
 
 func (a *aggregateFunc) Value(ctx Context) {
 	a.ctx = ctx
+	if !a.stepped {
+		// SQLite invokes xFinal exactly once per group, including the
+		// implicit single-group case of an ungrouped aggregate over an
+		// empty input. The coroutine in CreateAggregateFunction only
+		// runs fn after the first Step, so call fn directly here with
+		// an empty seq to preserve those semantics.
+		a.stop()
+		a.fn(&a.ctx, func(yield func([]Value) bool) {})
+		return
+	}
 	a.stop()
 }
 

--- a/func_seq_test.go
+++ b/func_seq_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"iter"
 	"log"
+	"testing"
 
 	"github.com/ncruces/go-sqlite3"
 )
@@ -56,4 +57,47 @@ func ExampleConn_CreateAggregateFunction() {
 	}
 	// Output:
 	// 2
+}
+
+// TestAggregateSeqFunction_EmptyInput verifies that the per-group
+// callback is invoked exactly once even when the group has zero
+// input rows, matching SQLite's xFinal semantics.
+func TestAggregateSeqFunction_EmptyInput(t *testing.T) {
+	db, err := sqlite3.Open(memory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	var calls int
+	err = db.CreateAggregateFunction("my_count", 0, 0,
+		func(ctx *sqlite3.Context, seq iter.Seq[[]sqlite3.Value]) {
+			calls++
+			var n int64
+			for range seq {
+				n++
+			}
+			ctx.ResultInt64(n)
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stmt, _, err := db.Prepare(`SELECT my_count() FROM (SELECT 1) WHERE FALSE`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Close()
+	if !stmt.Step() {
+		t.Fatalf("no row: %v", stmt.Err())
+	}
+	if got := stmt.ColumnType(0); got == sqlite3.NULL {
+		t.Errorf("aggregate over empty input: got NULL, want 0")
+	}
+	if got, want := stmt.ColumnInt64(0), int64(0); got != want {
+		t.Errorf("my_count() over empty input = %d, want %d", got, want)
+	}
+	if calls != 1 {
+		t.Errorf("callback invocations = %d, want 1", calls)
+	}
 }


### PR DESCRIPTION
Fixes #389.

`CreateAggregateFunction` never invokes the user's `AggregateSeqFunction` when a group has zero input rows, because the `iter.Pull` coroutine only runs the callback after the first `Step`. SQLite's `xFinal` contract calls for exactly one invocation per group, so an ungrouped custom aggregate over an empty input returns `NULL` instead of the documented value (e.g. `0` for a count).

Track whether `Step` ran on the `aggregateFunc`, and if not, invoke the user callback directly from `Value` with an empty `seq`. The coroutine path is unchanged for the common case.

Verified with the issue's repro:

```
builtin count(*)     -> 0
custom my_count()    -> 0   (was: NULL)
```

Added `TestAggregateSeqFunction_EmptyInput` which fails on `main` and passes with the fix. Existing `go test -race ./...` is green on `.` and `./tests/...`.