### PR TITLE
Add URIBoolean and URIInt64 to vfs.Filename

### DIFF
--- a/vfs/filename.go
+++ b/vfs/filename.go
@@ -122,6 +122,38 @@ func (n *Filename) URIParameter(key string) string {
 	}
 }
 
+// URIBoolean returns the value of a URI parameter interpreted as a boolean,
+// or def if the parameter is not set or is not a valid boolean.
+//
+// https://sqlite.org/c3ref/uri_boolean.html
+func (n *Filename) URIBoolean(key string, def bool) bool {
+	if n == nil || n.zPath == 0 {
+		return def
+	}
+
+	var b int32
+	if def {
+		b = 1
+	}
+	ptr := n.wrp.NewString(key)
+	defer n.wrp.Free(ptr)
+	return n.wrp.Xsqlite3_uri_boolean(int32(n.zPath), int32(ptr), b) != 0
+}
+
+// URIInt64 returns the value of a URI parameter interpreted as an integer,
+// or def if the parameter is not set or is not a valid integer.
+//
+// https://sqlite.org/c3ref/uri_boolean.html
+func (n *Filename) URIInt64(key string, def int64) int64 {
+	if n == nil || n.zPath == 0 {
+		return def
+	}
+
+	ptr := n.wrp.NewString(key)
+	defer n.wrp.Free(ptr)
+	return n.wrp.Xsqlite3_uri_int64(int32(n.zPath), int32(ptr), def)
+}
+
 // URIParameters obtains values for URI parameters.
 //
 // https://sqlite.org/c3ref/uri_boolean.html

--- a/vfs/filename_test.go
+++ b/vfs/filename_test.go
@@ -1,0 +1,77 @@
+package vfs_test
+
+import (
+	"testing"
+
+	"github.com/ncruces/go-sqlite3"
+	"github.com/ncruces/go-sqlite3/internal/testcfg"
+	"github.com/ncruces/go-sqlite3/vfs"
+)
+
+type uriVFS struct {
+	seen bool
+
+	on, off, badBool, missingBool bool
+	num, badNum, missingNum       int64
+}
+
+func (v *uriVFS) Open(name string, flags vfs.OpenFlag) (vfs.File, vfs.OpenFlag, error) {
+	return nil, flags, sqlite3.CANTOPEN
+}
+
+func (v *uriVFS) OpenFilename(name *vfs.Filename, flags vfs.OpenFlag) (vfs.File, vfs.OpenFlag, error) {
+	if flags&vfs.OPEN_MAIN_DB != 0 {
+		v.seen = true
+		v.on = name.URIBoolean("on", false)
+		v.off = name.URIBoolean("off", true)
+		v.badBool = name.URIBoolean("word", true)
+		v.missingBool = name.URIBoolean("absent", true)
+		v.num = name.URIInt64("num", -1)
+		v.badNum = name.URIInt64("word", -1)
+		v.missingNum = name.URIInt64("absent", -1)
+	}
+	return nil, flags, sqlite3.CANTOPEN
+}
+
+func (v *uriVFS) Delete(name string, syncDir bool) error { return nil }
+func (v *uriVFS) Access(name string, flags vfs.AccessFlag) (bool, error) {
+	return false, nil
+}
+func (v *uriVFS) FullPathname(name string) (string, error) { return name, nil }
+
+func TestFilename_URITyped(t *testing.T) {
+	var got uriVFS
+	vfs.Register("urityped", &got)
+	defer vfs.Unregister("urityped")
+
+	conn, err := sqlite3.OpenContext(testcfg.Context(t),
+		"file:test.db?vfs=urityped&on=yes&off=0&word=hello&num=42")
+	if err == nil {
+		conn.Close()
+	}
+
+	if !got.seen {
+		t.Fatal("main database was never opened through the VFS")
+	}
+	if !got.on {
+		t.Error("URIBoolean(on) = false, want true")
+	}
+	if got.off {
+		t.Error("URIBoolean(off) = true, want false")
+	}
+	if !got.badBool {
+		t.Error("URIBoolean(word) = false, want default true")
+	}
+	if !got.missingBool {
+		t.Error("URIBoolean(absent) = false, want default true")
+	}
+	if got.num != 42 {
+		t.Errorf("URIInt64(num) = %d, want 42", got.num)
+	}
+	if got.badNum != -1 {
+		t.Errorf("URIInt64(word) = %d, want default -1", got.badNum)
+	}
+	if got.missingNum != -1 {
+		t.Errorf("URIInt64(absent) = %d, want default -1", got.missingNum)
+	}
+}


### PR DESCRIPTION
Following up on #126 (wrap more of the SQLite API).

`vfs.Filename` already has `URIParameter` for reading string URI parameters, but there was no typed accessor for the boolean and integer forms, so callers had to parse the string themselves. This adds `URIBoolean` and `URIInt64`, which wrap `sqlite3_uri_boolean` and `sqlite3_uri_int64`, so values are interpreted exactly the way SQLite does (for example `on`, `yes`, `1` for booleans) and fall back to a caller supplied default when the parameter is absent or not a valid value.

Added a test that opens a database through a VFS and checks the parsed values against a URI.
